### PR TITLE
Optimizations

### DIFF
--- a/src/main/java/com/telepathicgrunt/worldblender/theblender/FeatureGrouping.java
+++ b/src/main/java/com/telepathicgrunt/worldblender/theblender/FeatureGrouping.java
@@ -123,6 +123,10 @@ public class FeatureGrouping {
 		return featureCache.getStats();
 	}
 
+	public void clearCache() {
+		featureCache.clear();
+	}
+
 	public Optional<JsonElement> encode(ConfiguredFeature<?, ?> feature) {
 		return featureCache.get(feature);
 	}

--- a/src/main/java/com/telepathicgrunt/worldblender/theblender/FeatureGrouping.java
+++ b/src/main/java/com/telepathicgrunt/worldblender/theblender/FeatureGrouping.java
@@ -103,20 +103,20 @@ public class FeatureGrouping {
 	 If cannot serialize, compare the feature itself to see if it is the same.
 	 */
 	public boolean serializeAndCompareFeature(ConfiguredFeature<?, ?> configuredFeature1, ConfiguredFeature<?, ?> configuredFeature2, boolean doDeepJSONCheck) {
+		// ConfiguredFeature doesn't implement equals() so just check the reference.
+		if (configuredFeature1 == configuredFeature2) return true;
+
 		Optional<JsonElement> optionalJsonElement1 = encode(configuredFeature1);
+		if (!optionalJsonElement1.isPresent()) return false;
+
 		Optional<JsonElement> optionalJsonElement2 = encode(configuredFeature2);
+		if (!optionalJsonElement2.isPresent()) return false;
 
 		// Compare the JSON to see if it's the exact same ConfiguredFeature.
-		if (optionalJsonElement1.isPresent() &&
-				optionalJsonElement2.isPresent()) {
-			JsonElement configuredFeatureJSON1 = optionalJsonElement1.get();
-			JsonElement configuredFeatureJSON2 = optionalJsonElement2.get();
-
-			return configuredFeatureJSON1.toString().equals(configuredFeatureJSON2.toString()) ||
-					(doDeepJSONCheck && getFeatureName(configuredFeatureJSON1).equals(getFeatureName(configuredFeatureJSON2)));
-		}
-
-		return configuredFeature1.equals(configuredFeature2);
+		JsonElement featureJson1 = optionalJsonElement1.get();
+		JsonElement featureJson2 = optionalJsonElement2.get();
+		return featureJson1.equals(featureJson2)
+				|| (doDeepJSONCheck && getFeatureName(featureJson1).equals(getFeatureName(featureJson2)));
 	}
 
 	public String getCacheStats() {

--- a/src/main/java/com/telepathicgrunt/worldblender/theblender/TheBlender.java
+++ b/src/main/java/com/telepathicgrunt/worldblender/theblender/TheBlender.java
@@ -132,6 +132,9 @@ public class TheBlender {
 		final long blendTimeMS = TimeUnit.NANOSECONDS.toMillis(System.nanoTime() - startNanos);
 		WorldBlender.LOGGER.debug("Blend time: {}ms", blendTimeMS);
 		WorldBlender.LOGGER.debug("Feature cache: {}", featureGrouping.getCacheStats());
+
+		// Dispose of cached json in-case future implementations keep this object around for longer.
+		featureGrouping.clearCache();
 	}
 	
 	private void apply(Biome blendedBiome) {

--- a/src/main/java/com/telepathicgrunt/worldblender/utils/CodecCache.java
+++ b/src/main/java/com/telepathicgrunt/worldblender/utils/CodecCache.java
@@ -1,0 +1,54 @@
+package com.telepathicgrunt.worldblender.utils;
+
+import com.google.gson.JsonElement;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.JsonOps;
+
+import java.util.IdentityHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+public class CodecCache<T> {
+    public static final int DEFAULT_CACHE_SIZE = 2048;
+
+    private final Codec<T> codec;
+    private final Map<T, Optional<JsonElement>> cache;
+    private final Function<T, Optional<JsonElement>> computeFunc;
+    private final AtomicInteger requestCount = new AtomicInteger(0);
+
+    private CodecCache(Codec<T> codec, Map<T, Optional<JsonElement>> backing) {
+        this.codec = codec;
+        this.cache = backing;
+        this.computeFunc = this::encode;
+    }
+
+    public void clear() {
+        cache.clear();
+    }
+
+    public Optional<JsonElement> get(T value) {
+        requestCount.incrementAndGet();
+        return cache.computeIfAbsent(value, computeFunc);
+    }
+
+    public String getStats() {
+        int size = cache.size();
+        int requests = requestCount.get();
+        return String.format("Size: %s, Requests: %s, Hits: %s", size, requests, requests - size);
+    }
+
+    private Optional<JsonElement> encode(T value) {
+        return codec.encodeStart(JsonOps.INSTANCE, value).result();
+    }
+
+    public static <T> CodecCache<T> of(Codec<T> codec) {
+        return new CodecCache<>(codec, new IdentityHashMap<>(DEFAULT_CACHE_SIZE));
+    }
+
+    public static <T> CodecCache<T> concurrent(Codec<T> codec) {
+        return new CodecCache<>(codec, new ConcurrentHashMap<>(DEFAULT_CACHE_SIZE));
+    }
+}

--- a/src/main/java/com/telepathicgrunt/worldblender/utils/CodecCache.java
+++ b/src/main/java/com/telepathicgrunt/worldblender/utils/CodecCache.java
@@ -27,6 +27,7 @@ public class CodecCache<T> {
 
     public void clear() {
         cache.clear();
+        requestCount.set(0);
     }
 
     public Optional<JsonElement> get(T value) {


### PR DESCRIPTION
This PR contains a couple of optimizations around encoding/comparing the configured features:
- Opt#1 - Caching - either due to feature instances being reused in multiple biomes, or WB's own processing, you end up encoding the same feature multiple times which can both eat up time and create a lot of relatively large but short-lived objects. The `CodecCache` adds a simple caching layer around the ConfiguredFeature codec ensuring the encode is only computed once per ConfiguredFeature instance. 
- Opt#2 - Comparing - just some minor reording of the `serializeAndCompareFeature` method can save unecessary computation by front-loading the cheap checks and returning early where possible. I also use `JsonElement#equals` in place of the `toString().equals()` - both result in recursive traversal of the json structure but the latter allocates alsorts to create the string before getting do the equality check, so the former should be noticeably quicker and produces less garbage.

### Testing
I tested using this fork, BYG v1.1.10, and BoP v13.0.0.426

For my baseline (ie pre-changes) 'blend time' I was getting around `13500ms`
With Opt#1 alone it was down to around `5500ms`
With Opt#1+2 active it was running at `3000ms`
Overall speed up of ~10 seconds 👍

The cache computed the json for `594` unique configured feature instances, and had a total of `264,481` requests.
This makes an average saving of over `440` duplicate encodes per configured feature.

### Notes
- Wasn't sure on the codestyle so feel free to beautify as you see fit.
- I've left the time measurement logging in the blendWorlds method. You may want to remove, idk.
- The default cache isn't thread-safe but there is a helper method there to switch to a concurrentmap-backed cache if needed.
- Testing required - I'm not familiar enough with this mod/dimension to be able to spot if I broke something (appears to work though) so this is provided as-is, no guarantees, yadayada XD